### PR TITLE
feat: Add API endpoint to create a new game

### DIFF
--- a/app/src/main/java/com/game/app/controller/GameController.java
+++ b/app/src/main/java/com/game/app/controller/GameController.java
@@ -1,0 +1,90 @@
+package com.game.app.controller;
+
+import com.game.app.dao.response.APIResponse;
+import com.game.app.persistence.model.Game;
+import com.game.app.persistence.model.Player;
+import com.game.app.persistence.repository.GameRepository;
+import com.game.app.services.service.GameService;
+import com.game.app.services.service.PlayerService;
+import lombok.RequiredArgsConstructor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/api/game")
+@RequiredArgsConstructor
+public class GameController {
+    @Autowired
+    PlayerService playerService;
+
+    @Autowired
+    GameService gameService;
+
+    @Autowired
+    GameRepository gameRepository;
+
+    Logger logger = LoggerFactory.getLogger(GameController.class);
+
+
+    @PostMapping("/create-game/{hostPlayerId}/{player2Id}")
+    public ResponseEntity<APIResponse<?>> createGame(
+            @PathVariable String hostPlayerId,
+            @PathVariable String player2Id
+    ) {
+        try {
+            logger.info("Create Game request:");
+
+            // Check if the host and second players exist
+            Player hostPlayer = playerService.getPlayerById(hostPlayerId);
+
+            Player player2 = playerService.getPlayerById(player2Id);
+
+            if (hostPlayer == null || player2 == null) {
+                return ResponseEntity
+                        .status(HttpStatus.CONFLICT)
+                        .body(new APIResponse<String>(
+                                false,
+                                "",
+                                "Host player or second player not found"));
+            }
+
+            if (!hostPlayer.isHost()) {
+                return ResponseEntity
+                        .status(HttpStatus.UNAUTHORIZED)
+                        .body(new APIResponse<String>(
+                                false,
+                                "",
+                                "Player do not have authority to create a game."));
+            }
+
+            // Create the game using the host player and second player
+            Game newGame = gameService.createGame(hostPlayer, player2);
+
+            if (newGame == null) {
+                return ResponseEntity
+                        .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                        .body(new APIResponse<String>(
+                                false,
+                                "",
+                                "An error occurred while creating the game"));
+            }
+
+            return ResponseEntity
+                    .ok(new APIResponse<Game>(true, newGame, "Game created successfully"));
+
+        } catch (Exception e) {
+            logger.error("An error occurred during game creation.", e);
+
+            return ResponseEntity
+                    .status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .body(new APIResponse<String>(
+                            false,
+                            "",
+                            "An error occurred while creating the game"));
+        }
+    }
+}

--- a/app/src/main/java/com/game/app/controller/PlayerController.java
+++ b/app/src/main/java/com/game/app/controller/PlayerController.java
@@ -26,7 +26,7 @@ public class PlayerController {
     @Autowired
     PlayerRepository playerRepository;
 
-    Logger logger = LoggerFactory.getLogger(PlayerServiceImpl.class);
+    Logger logger = LoggerFactory.getLogger(PlayerController.class);
 
 
     @PostMapping("/create-player")

--- a/app/src/main/java/com/game/app/persistence/model/Game.java
+++ b/app/src/main/java/com/game/app/persistence/model/Game.java
@@ -33,4 +33,10 @@ public class Game {
 
     @Column(name = "winner_id")
     private String winnerId; // PlayerId of the winner (null until game ends)
+
+    @Column(name = "created_by_player_id")
+    private String createdByPlayerId; // PlayerId of the player who created the game
+
+    @Column(name = "is_active")
+    private boolean isActive;
 }

--- a/app/src/main/java/com/game/app/persistence/repository/GameRepository.java
+++ b/app/src/main/java/com/game/app/persistence/repository/GameRepository.java
@@ -5,6 +5,9 @@ import com.game.app.persistence.model.Place;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.List;
+
 @Repository
 public interface GameRepository extends JpaRepository<Game, String> {
+    List<Game> findAllActiveGamesByPlayer1IdAndIsActiveTrue(String hostPlayerId);
 }

--- a/app/src/main/java/com/game/app/services/service/GameService.java
+++ b/app/src/main/java/com/game/app/services/service/GameService.java
@@ -1,4 +1,10 @@
 package com.game.app.services.service;
 
+import com.game.app.dao.request.CreatePlayerRequest;
+import com.game.app.persistence.model.Game;
+import com.game.app.persistence.model.Player;
+
 public interface GameService {
+    public Game createGame(Player hostPlayer, Player player2);
+
 }

--- a/app/src/main/java/com/game/app/services/service/PlayerService.java
+++ b/app/src/main/java/com/game/app/services/service/PlayerService.java
@@ -8,4 +8,7 @@ public interface PlayerService {
     public Player createPlayer(CreatePlayerRequest request);
 
     public String isPlayerDataValid(String email, String name);
+
+    public Player getPlayerById(String playerId);
+
 }

--- a/app/src/main/java/com/game/app/services/serviceImpl/GameServiceImpl.java
+++ b/app/src/main/java/com/game/app/services/serviceImpl/GameServiceImpl.java
@@ -1,0 +1,55 @@
+package com.game.app.services.serviceImpl;
+
+import com.game.app.persistence.model.Game;
+import com.game.app.persistence.model.Player;
+import com.game.app.persistence.repository.GameRepository;
+import com.game.app.persistence.repository.PlayerRepository;
+import com.game.app.services.service.GameService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.UUID;
+
+@Service
+public class GameServiceImpl implements GameService {
+
+    @Autowired
+    GameRepository gameRepository;
+
+    @Autowired
+    PlayerRepository playerRepository;
+
+    @Override
+    public Game createGame(Player hostPlayer, Player player2) {
+        // Find all existing active games associated with the host player
+        List<Game> existingGames = gameRepository.findAllActiveGamesByPlayer1IdAndIsActiveTrue(hostPlayer.getId());
+
+        // Soft delete all existing active games
+        for (Game existingGame : existingGames) {
+            existingGame.setActive(false); // Mark the game as inactive
+        }
+        gameRepository.saveAll(existingGames); // Update all existing game entities
+
+        // Create a new game entity with the host player as player1 and second player as player2
+        Game newGame = Game.builder()
+                .id(UUID.randomUUID().toString())
+                .player1(hostPlayer)
+                .player2(player2)
+                .isActive(true)
+                .createdByPlayerId(hostPlayer.getId())
+                .turnCount(0)
+                .build();
+
+        hostPlayer.setCashBalance(1000);
+        player2.setCashBalance(1000);
+
+        // Save the new game entity and update player entities
+        Game savedGame = gameRepository.save(newGame);
+        playerRepository.save(hostPlayer);
+        playerRepository.save(player2);
+
+        // Save the new game entity
+        return savedGame;
+    }
+}

--- a/app/src/main/java/com/game/app/services/serviceImpl/PlayerServiceImpl.java
+++ b/app/src/main/java/com/game/app/services/serviceImpl/PlayerServiceImpl.java
@@ -50,6 +50,11 @@ public class PlayerServiceImpl implements PlayerService {
         return null;
     }
 
+    @Override
+    public Player getPlayerById(String playerId) {
+        return playerRepository.findById(playerId).orElse(null);
+    }
+
     public String isUserDataValid(String email, String password, String fname, String lname) {
         if (email == null  || email.length() < 3
                 || password == null || password.length() == 0


### PR DESCRIPTION
-Implemented the POST /create-game endpoint to allow hosts  (players) to create a new Monopoly game, discarding any existing game. The endpoint initializes the game state, including the host player and basic game settings.